### PR TITLE
Add initial GitLab compose setup under gitlab/

### DIFF
--- a/gitlab/compose.yaml
+++ b/gitlab/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:17.11.0-ce.0
+    container_name: gitlab
+    restart: unless-stopped
+    hostname: gitlab.local
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.local'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+    ports:
+      - "80:80"
+      - "443:443"
+      - "2222:22"
+    volumes:
+      - ./config:/etc/gitlab
+      - ./logs:/var/log/gitlab
+      - ./data:/var/opt/gitlab
+    shm_size: "256m"


### PR DESCRIPTION
### Motivation
- ドキュメントに従い GitLab 環境の構築を始めるために、最初の Docker Compose ベースラインを `gitlab/` 配下に追加しました。

### Description
- 新規ファイル `gitlab/compose.yaml` を追加し、`gitlab` サービスとして `gitlab/gitlab-ce:17.11.0-ce.0` イメージと `container_name`/再起動ポリシー/`hostname` を定義し、HTTP/HTTPS/SSH ポートを `80:80`/`443:443`/`2222:22` で公開、永続化ボリュームとして `./config:/etc/gitlab`/`./logs:/var/log/gitlab`/`./data:/var/opt/gitlab` を設定し、`GITLAB_OMNIBUS_CONFIG` で `external_url 'http://gitlab.local'` と `gitlab_shell_ssh_port` を 2222 に指定し、`shm_size: "256m"` を設定しました。

### Testing
- `git status` と `git commit` を実行して変更をコミットし成功（コミット `9c8c4e8`）したことを確認しましたが、`docker compose -f gitlab/compose.yaml config` による Compose 構成検証はこの環境で `docker: command not found` によって実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76ceff6c08332823d7ea4e8dbf343)